### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,17 +13,17 @@ SFPddm	KEYWORD1
 #######################################
 
 begin	KEYWORD2
-getRawInfo KEYWORD2
-getStatus KEYWORD2
-getSupported KEYWORD2
-readMeasurements KEYWORD2
-getControl KEYWORD2
-setControl KEYWORD2
-getTemperature KEYWORD2
-getVoltage KEYWORD2
-getTXcurrent KEYWORD2
-getTXpower KEYWORD2
-getRXpower KEYWORD2
+getRawInfo	KEYWORD2
+getStatus	KEYWORD2
+getSupported	KEYWORD2
+readMeasurements	KEYWORD2
+getControl	KEYWORD2
+setControl	KEYWORD2
+getTemperature	KEYWORD2
+getVoltage	KEYWORD2
+getTXcurrent	KEYWORD2
+getTXpower	KEYWORD2
+getRXpower	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords